### PR TITLE
Pure to of

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/Gen.ts
+++ b/src/Gen.ts
@@ -46,8 +46,8 @@ interface GenEnv {
 
 export class Gen<A> {
   private constructor(private readonly gen: (env: GenEnv) => Tree<A>) {}
-  static pure<A>(a: A): Gen<A> {
-    return new Gen(() => Tree.pure(a))
+  static of<A>(a: A): Gen<A> {
+    return new Gen(() => Tree.of(a))
   }
   map<B>(f: (a: A) => B): Gen<B> {
     return new Gen(env => this.gen(env).map(f))
@@ -178,7 +178,7 @@ export class Gen<A> {
   }
   replicate(n: number): Gen<A[]> {
     if (n <= 0) {
-      return Gen.pure([] as A[])
+      return Gen.of([] as A[])
     } else {
       return this.pair(this.replicate(n - 1)).map(([x, xs]) => [x, ...xs])
     }

--- a/src/Tree.ts
+++ b/src/Tree.ts
@@ -7,7 +7,7 @@ export interface StrictTree<A> {
 
 export class Tree<A> {
   constructor(readonly top: A, readonly forest: () => Tree<A>[]) {}
-  static pure<A>(a: A): Tree<A> {
+  static of<A>(a: A): Tree<A> {
     return new Tree(a, () => [])
   }
   static tree<A>(top: A, forest: () => Tree<A>[]): Tree<A> {
@@ -17,7 +17,7 @@ export class Tree<A> {
     return new Tree(top, () => forest)
   }
   map<B>(f: (a: A, depth: number) => B): Tree<B> {
-    return this.then((a: A, depth: number) => Tree.pure(f(a, depth)))
+    return this.then((a: A, depth: number) => Tree.of(f(a, depth)))
   }
   then<B>(f: (a: A, depth: number) => Tree<B>, depth = 0): Tree<B> {
     const t = f(this.top, depth)
@@ -25,7 +25,7 @@ export class Tree<A> {
   }
 
   left_first_pair<B>(tb: Tree<B>): Tree<[A, B]> {
-    return this.then(a => tb.then(b => Tree.pure(Utils.pair(a, b))))
+    return this.then(a => tb.then(b => Tree.of(Utils.pair(a, b))))
   }
   fair_pair<B>(tb: Tree<B>): Tree<[A, B]> {
     return Tree.dist({a: this, b: tb}).map(p => Utils.pair(p.a, p.b))

--- a/test/main.ts
+++ b/test/main.ts
@@ -55,7 +55,7 @@ const GTree = <A>(g: Gen<A>) =>
   Gen.size().then(s0 => {
     function go(s: number): Gen<Tree<A>> {
       return Gen.frequency([
-        [1, g.map(Tree.pure)],
+        [1, g.map(Tree.of)],
         [
           s,
           g.then(top =>
@@ -108,7 +108,7 @@ qc('traverse homomorphic with no overlap', Gen.nat.pojo().replicate(2), ([a, b],
 
 qc('tree join left', GTree(Gen.nat), t =>
   Utils.deepEquals(
-    Tree.pure(t)
+    Tree.of(t)
       .then(t => t)
       .force(),
     t.force()
@@ -116,24 +116,24 @@ qc('tree join left', GTree(Gen.nat), t =>
 )
 
 qc('tree join right', GTree(Gen.nat), t =>
-  Utils.deepEquals(t.then(j => Tree.pure(j)).force(), t.force())
+  Utils.deepEquals(t.then(j => Tree.of(j)).force(), t.force())
 )
 
 qc('gen join left', Gen.record({i: Gen.nat, seed: Gen.nat, size: Gen.size()}), d =>
   Utils.deepEquals(
-    Gen.pure(Gen.pure(d.i))
+    Gen.of(Gen.of(d.i))
       .then(g => g)
       .sample(d.size, d.seed),
-    Gen.pure(d.i).sample(d.size, d.seed)
+    Gen.of(d.i).sample(d.size, d.seed)
   )
 )
 
 qc('gen join right', Gen.record({i: Gen.nat, seed: Gen.nat, size: Gen.size()}), d =>
   Utils.deepEquals(
-    Gen.pure(d.i)
-      .then(j => Gen.pure(j))
+    Gen.of(d.i)
+      .then(j => Gen.of(j))
       .sample(d.size, d.seed),
-    Gen.pure(d.i).sample(d.size, d.seed)
+    Gen.of(d.i).sample(d.size, d.seed)
   )
 )
 
@@ -177,7 +177,7 @@ test('unexpected success', t => {
 })
 
 test('exception evaluating', t => {
-  const res = QuickCheck(Gen.pure({}), _ => {
+  const res = QuickCheck(Gen.of({}), _ => {
     throw 'OOPS'
   })
   t.deepEquals(res.ok, false)
@@ -188,7 +188,7 @@ test('exception evaluating', t => {
 
 test('exception generating', t => {
   const res = QuickCheck(
-    Gen.pure({}).then(_ => {
+    Gen.of({}).then(_ => {
       throw 'Oops'
     }),
     _ => true


### PR DESCRIPTION
It is customary to call `pure` for `of` in TypeScript/JavaScript. This is a precedence set by [Fantasy Land](https://github.com/fantasyland/fantasy-land).

This PR renames `pure` to `of`. It also adds a simple `.gitignore` to exclude `node_modules` and the compiled files.