### PR TITLE
Use lazy list

### DIFF
--- a/src/Gen.ts
+++ b/src/Gen.ts
@@ -29,12 +29,14 @@ export class Gen<A> {
   withTree<B>(f: (ta: Tree<A>) => Tree<B>): Gen<B> {
     return new Gen(env => f(this.gen(env)))
   }
+  /*
   replaceShrinks(f: (forest: Tree<A>[]) => Tree<A>[]): Gen<A> {
     return new Gen(env => {
       const {top, forest} = this.gen(env)
       return new Tree(top, () => f(forest()))
     })
   }
+  */
 
   sample(size = 10, seed?: number): A {
     return this.sampleWithShrinks(size, seed).top

--- a/src/lazylist.ts
+++ b/src/lazylist.ts
@@ -1,0 +1,67 @@
+export type Thunk<A> = {
+  forced: boolean
+  expr: (() => A) | undefined
+  memorized: A | undefined
+}
+
+function thunk<A>(expr: () => A): Thunk<A> {
+  return {expr, memorized: undefined}
+}
+
+export function force<A>(thunk: Thunk<A>): A {
+  if (thunk.expr !== undefined) {
+    thunk.memorized = thunk.expr!()
+    thunk.expr = undefined
+  }
+  return thunk.memorized!
+}
+
+/**
+ * A lazy list is a thunk that is either a pair of a value an a tail or the
+ * empty list (represented as undefined)
+ */
+export type LazyList<A> = Thunk<{head: A; tail: LazyList<A>} | undefined>
+
+export const nil = thunk(() => undefined)
+
+export function cons<A>(head: A, tail: LazyList<A>) {
+  return thunk(() => ({head, tail}))
+}
+
+export function map<A, B>(f: (a: A) => B, l: LazyList<A>): LazyList<B> {
+  return thunk(() => {
+    const as = force(l)
+    return as ? {head: f(as.head), tail: map(f, as.tail)} : undefined
+  })
+}
+
+export function concat<A>(l1: LazyList<A>, l2: LazyList<A>): LazyList<A> {
+  return thunk(() => {
+    const as = force(l1)
+    return as ? {head: as.head, tail: concat(as.tail, l2)} : force(l2)
+  })
+}
+
+export function flatten<A>(ls: LazyList<LazyList<A>>): LazyList<A> {
+  return thunk(() => {
+    const as = force(ls)
+    return as ? force(concat(as.head, flatten(as.tail))) : undefined
+  })
+}
+
+export function fromArray<A>(arr: A[]): LazyList<A> {
+  function go(idx: number, arr: A[]): LazyList<A> {
+    return thunk(() => (idx === arr.length ? undefined : {head: arr[idx], tail: go(idx + 1, arr)}))
+  }
+  return go(0, arr)
+}
+
+export function toArray<A>(l: LazyList<A>): A[] {
+  const out = []
+  let child = force(l)
+  while (child !== undefined) {
+    out.push(child.head)
+    child = force(child.tail)
+  }
+  return out
+}

--- a/test/Tree.ts
+++ b/test/Tree.ts
@@ -1,4 +1,5 @@
-import {Tree} from '../src/Tree'
+import {Tree, shrinkNumber} from '../src/Tree'
+import * as Lz from '../src/lazylist'
 import * as QC from '../src/main'
 import * as Gen from '../src/main'
 import * as test from 'tape'
@@ -16,7 +17,7 @@ const GTree = <A>(g: QC.Gen<A>) =>
             Gen.between(2, 5).chain(n =>
               go(Math.max(0, Math.round(s / n)))
                 .replicate(n)
-                .map(tree => new Tree(top, () => tree))
+                .map(tree => new Tree(top, Lz.fromArray(tree)))
             )
           ),
         ],
@@ -37,3 +38,14 @@ check('tree join left', GTree(Gen.nat), (t, p) =>
 check('tree join right', GTree(Gen.bin), (t, p) =>
   p.equals(t.chain(j => Tree.of(j)).force(), t.force())
 )
+
+test('dfs only forces the path it takes', t => {
+  t.plan(1)
+  let called = 0
+  const tree = shrinkNumber(100000, 0).map(n => {
+    called++
+    return n
+  })
+  tree.left_first_search(n => n > 0)
+  t.ok(called < 22)
+})

--- a/test/shrinking.ts
+++ b/test/shrinking.ts
@@ -1,6 +1,7 @@
 import * as QC from '../src/main'
 import * as Gen from '../src/main'
 import * as Utils from '../src/Utils'
+import * as Tree from '../src/Tree'
 import * as test from 'tape'
 
 {
@@ -36,3 +37,28 @@ import * as test from 'tape'
     })
   })
 }
+
+test(`shrinking finds counter example in few steps`, t => {
+  t.plan(2)
+  let found = false
+  let called = 0
+  const r = QC.search(
+    Gen.natural,
+    x => {
+      const result = 10 < x && x < 10000
+      if (result === false) {
+        if (found) {
+          called++
+        } else {
+          found = true
+        }
+      }
+      return result
+    },
+    QC.option({maxShrinks: 1000})
+  )
+  t.ok(called < 20)
+  if (!r.ok && r.reason == 'counterexample') {
+    t.deepEquals(r.counterexample, 0)
+  }
+})


### PR DESCRIPTION
This code creates a tree, maps a function over it and does a depth-first search. It then measures how many times the mapping function is invoked during a depth-first search.
```ts
  t.plan(1)
  let called = 0
  const tree = shrinkNumber(100000, 0).map(n => {
    called++
    return n
  })
  tree.left_first_search(n => n > 0)
  t.ok(called < 22)
```
On master the map function is called 291 times. With this PR the map function is called 18 times!

This PR also includes a test "_shrinking to 79,79 pair finds counterexample in few steps_" that measures how many times a prop function is called to shrink a counterexample. On master, the prop function is called about 350 times during the shrinking. With this PR the prop function is called less than 20 times.

The PR achieves the above by introducing more laziness. Currently, the computation of the forest of a tree is done lazily. But only with a single thunk. So simply looking at the first leaf in the forest (which is what the dfs wants to do) forces the computation of _all_ the leafs.

This PR solves the problem with an implementation of a lazy cons-list. It supports `map`, `concat`, `flatten` in a lazy way. It is also possible to traverse the list lazily. This has the huge benefit that the depth first search only forces the computation of the nodes that it actually needs the value of. This should give huge performance improvements.

Btw, the beforementioned "_shrinking to 79,79 pair finds counter example in few steps_" test is quite contrived and slightly random. Maybe you have a better alternative?

I also commented out `replaceShrinks`. It wasn't used anywhere so I couldn't determine how best to convert it. Should the `f` argument produc lazy lists or should its return value be converted to a lazy list?