### PR TITLE
Add prepare script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "scripts": {
     "build": "tsc",
     "prettier": "prettier --list-different --write \"{src,test}/**/*.ts\"",
+    "prepare": "npm run build",
     "test": "ts-node node_modules/tape/bin/tape test/*.ts | tap-spec"
   },
   "prettier": {


### PR DESCRIPTION
Until #7 gets resolved and an npm package is created it would be nice to be able to install the library directly from git. This is [possible](https://docs.npmjs.com/cli/install) with npm and the documentation says:

> If the package being installed contains a prepare script, its dependencies and devDependencies will be installed, and the prepare script will be run, before the package is packaged and installed.

Therefore this PR adds a `prepare` script to `package.json`. It is my understanding that the package can then be installed directly from git and that it will automatically be build.